### PR TITLE
fixed profile header section in mobile

### DIFF
--- a/frontend/src/custom.scss
+++ b/frontend/src/custom.scss
@@ -57,5 +57,5 @@ body {
 }
 
 .user-info {
-  min-width: 800px;
+  width: 100%;
 }


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixed profile header section having a fixed min-width of 800px, which results in the section beeing cut of on mobile screens
